### PR TITLE
Parenthesize the output in showRecord if high precedence is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# next
+
+- Fix a bug where `showRecord` would not parenthesize the output if a high
+  enough precedence were supplied.
+
 # 0.1.1.0
 
 - Added `showInfixl`, `showInfixr`, `showInfixl'`, `showInfixr'`.

--- a/src/Text/Show/Combinators.hs
+++ b/src/Text/Show/Combinators.hs
@@ -184,8 +184,8 @@ type ShowFields = ShowS
 -- | Show a record. The first argument is the constructor name.
 -- The second represents the set of record fields.
 showRecord :: String -> ShowFields -> PrecShowS
-showRecord con showFields _ =
-  showString con . showSpace . showChar '{' . showFields . showChar '}'
+showRecord con showFields d = showParen (d > appPrec)
+  (showString con . showSpace . showChar '{' . showFields . showChar '}')
 
 -- | Show a single record field: a field name and a value separated by @\'=\'@.
 showField :: String -> PrecShowS -> ShowFields

--- a/test/test.hs
+++ b/test/test.hs
@@ -30,11 +30,11 @@ showL :: [Int] -> PrecShowS
 showL [] = showCon "[]"
 showL (x : xs) = showInfixl ":" 5 (showL xs) (flip showsPrec x)
 
-check :: Show a => (a -> PrecShowS) -> a -> IO ()
-check show' x = assertEqual s s'
+check :: Show a => (a -> PrecShowS) -> Int -> a -> IO ()
+check show' d x = assertEqual s s'
   where
-    s = show x
-    s' = show' x 0 ""
+    s = showsPrec d x ""
+    s' = show' x d ""
 
 assertEqual :: (Eq a, Show a) => a -> a -> IO ()
 assertEqual s s' =
@@ -48,10 +48,10 @@ unPS p x = p x 0 ""
 
 main :: IO ()
 main = do
-  check smt1 (C () ())
-  check smt2 (C (C () ()) (() :+: ()))
-  check smt2 ((() :+: ()) :+: (() :+: ()))
-  check smt2 (R (C () ()) (C () ()))
+  check smt1  0 (C () ())
+  check smt2  0 (C (C () ()) (() :+: ()))
+  check smt2  0 ((() :+: ()) :+: (() :+: ()))
+  check smt2 11 (R (C () ()) (C () ()))
   assertEqual (unPS showR [1,2,3]) "1 : 2 : 3 : []"
   assertEqual (unPS showL [1,2,3]) "[] : 3 : 2 : 1"
   where


### PR DESCRIPTION
This addresses part (3) of https://github.com/Lysxia/generic-data/issues/30#issuecomment-602216159.